### PR TITLE
Add changepoint detection and stage feature flags

### DIFF
--- a/etl/stage_segmentation.py
+++ b/etl/stage_segmentation.py
@@ -7,6 +7,95 @@ from utils.io import read_csv, save_df
 from utils.preprocessing import savgol_slope
 from utils.constants import STEPS, TAGS
 from etl.validation import validate_batch, validate_ts_signal
+import ruptures as rpt
+from typing import List
+
+WINDOW = pd.Timedelta(minutes=3)
+
+
+def detect_changepoints(ts_wide: pd.DataFrame) -> pd.DataFrame:
+    """Detect changepoints for key signals using PELT algorithm.
+
+    Parameters
+    ----------
+    ts_wide : pd.DataFrame
+        Wide time series indexed by timestamps with columns among
+        ['T', 'pH', 'Vac', 'Flow'].
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with columns ['signal', 'ts'] giving detected changepoint
+        timestamps for each signal.
+    """
+
+    cp_rows: List[dict] = []
+    for col in ['T', 'pH', 'Vac', 'Flow']:
+        if col not in ts_wide:
+            continue
+        s = ts_wide[col].dropna()
+        if len(s) < 10:
+            continue
+        # run PELT to find up to 7 breakpoints (8 steps)
+        algo = rpt.Pelt(model="rbf").fit(s.values)
+        try:
+            bkps = algo.predict(n_bkps=7)
+        except Exception:
+            # fallback with penalty if n_bkps not feasible
+            bkps = algo.predict(pen=3)
+        for b in bkps[:-1]:  # last breakpoint is len(series)
+            ts = s.index[min(b, len(s)-1)]
+            cp_rows.append({'signal': col, 'ts': pd.Timestamp(ts)})
+    return pd.DataFrame(cp_rows)
+
+
+def adjust_segments_with_changepoints(ts: pd.DataFrame, segs: pd.DataFrame) -> pd.DataFrame:
+    """Adjust segment boundaries if changepoints agree across signals.
+
+    Parameters
+    ----------
+    ts : pd.DataFrame
+        Long-format timeseries with columns ['batch_id','ts','tag','value'].
+    segs : pd.DataFrame
+        Initial segments from events with ['batch_id','step','start_ts','end_ts'].
+
+    Returns
+    -------
+    pd.DataFrame
+        Adjusted segments DataFrame.
+    """
+
+    ts = ts.copy()
+    ts['ts'] = pd.to_datetime(ts['ts'])
+    out = segs.copy()
+    for bid, g in out.groupby('batch_id'):
+        batch_ts = ts[ts['batch_id'] == bid]
+        P = batch_ts.pivot_table(index='ts', columns='tag', values='value').sort_index()
+        cps = detect_changepoints(P)
+        if cps.empty:
+            continue
+        seg_idx = g.sort_values('start_ts').index.tolist()
+        g_sorted = out.loc[seg_idx]
+        g_sorted = g_sorted.sort_values('start_ts').reset_index()
+        for i in range(len(g_sorted)):
+            # adjust start boundary (not for first step)
+            if i > 0:
+                boundary = g_sorted.loc[i, 'start_ts']
+                near = cps[(cps['ts'] >= boundary - WINDOW) & (cps['ts'] <= boundary + WINDOW)]
+                if near['signal'].nunique() >= 2:
+                    new_ts = near['ts'].median()
+                    g_sorted.loc[i, 'start_ts'] = new_ts
+                    g_sorted.loc[i-1, 'end_ts'] = new_ts
+            # adjust end boundary (not for last step)
+            if i < len(g_sorted) - 1:
+                boundary = g_sorted.loc[i, 'end_ts']
+                near = cps[(cps['ts'] >= boundary - WINDOW) & (cps['ts'] <= boundary + WINDOW)]
+                if near['signal'].nunique() >= 2:
+                    new_ts = near['ts'].median()
+                    g_sorted.loc[i, 'end_ts'] = new_ts
+                    g_sorted.loc[i+1, 'start_ts'] = new_ts
+        out.update(g_sorted.set_index('index'))
+    return out
 
 def build_segments_from_events(op_event: pd.DataFrame):
     # assume events cover all steps with timestamps; build (start,end) per step per batch
@@ -44,6 +133,21 @@ def build_stage_features(ts: pd.DataFrame, segs: pd.DataFrame):
                 row[f'{col}_std']  = float(s.std())
                 row[f'{col}_max']  = float(s.max())
                 row[f'{col}_min']  = float(s.min())
+        # state flags
+        if 'T' in P and P['T'].dropna().size:
+            tmax = P['T'].max()
+            row['heat_ok'] = bool((tmax >= 95) and (tmax <= 98))
+        else:
+            row['heat_ok'] = False
+        if 'pH' in P and P['pH'].dropna().size:
+            ph_max = P['pH'].max(); ph_min = P['pH'].min()
+            row['pH_window'] = bool((ph_min >= 8.4) and (ph_max <= 9.6))
+        else:
+            row['pH_window'] = False
+        if 'DehydV' in P and P['DehydV'].dropna().size:
+            row['vacuum_leq_16L'] = bool(P['DehydV'].max() <= 16000)
+        else:
+            row['vacuum_leq_16L'] = False
         feats.append(row)
     return pd.DataFrame(feats)
 
@@ -58,6 +162,7 @@ def main():
     op = read_csv('op_event.csv')
     op['ts'] = pd.to_datetime(op['ts'])
     segs = build_segments_from_events(op)
+    segs = adjust_segments_with_changepoints(ts, segs)
     segs.to_csv(Path(__file__).resolve().parents[1] / 'data' / 'synthetic' / 'segments.csv', index=False)
     feat = build_stage_features(ts, segs)
     save_df(feat, 'stage_features.csv')

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,3 @@ pyyaml>=6.0
 joblib>=1.3
 tslearn>=0.6.3
 great_expectations>=0.18
-ruptures>=1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pyyaml>=6.0
 joblib>=1.3
 tslearn>=0.6.3
 great_expectations>=0.18
+ruptures>=1.1

--- a/tests/test_stage_segmentation.py
+++ b/tests/test_stage_segmentation.py
@@ -1,0 +1,68 @@
+import pandas as pd
+import numpy as np
+from datetime import datetime, timedelta
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from etl.stage_segmentation import (
+    build_segments_from_events,
+    adjust_segments_with_changepoints,
+    build_stage_features,
+)
+from etl.generate_synthetic_data import step_durations, make_timegrid, synth_curve
+
+
+def make_synthetic_batch():
+    rng = np.random.default_rng(0)
+    durs = step_durations()
+    seg_idx, total = make_timegrid(durs, dt=60)
+    signals = synth_curve(durs, seg_idx)
+    start = datetime(2025, 1, 1, 8, 0, 0)
+    times = [start + timedelta(seconds=i * 60) for i in range(total)]
+
+    # build long-format timeseries
+    rows = []
+    for i, ts in enumerate(times):
+        for tag, arr in signals.items():
+            rows.append({"batch_id": "B1", "ts": ts, "tag": tag, "value": arr[i]})
+    ts_long = pd.DataFrame(rows)
+
+    # event times with jitter up to ±2 min
+    events = []
+    for step, (i0, i1) in enumerate(seg_idx, start=1):
+        jitter = int(rng.integers(-120, 120))
+        ts_event = start + timedelta(seconds=i0 * 60 + jitter)
+        events.append({"batch_id": "B1", "step": step, "ts": ts_event})
+    # final end event
+    events.append({"batch_id": "B1", "step": 8, "ts": start + timedelta(seconds=seg_idx[-1][1] * 60)})
+    op_event = pd.DataFrame(events)
+
+    true_bounds = [start + timedelta(seconds=i0 * 60) for i0, _ in seg_idx]
+    true_bounds.append(start + timedelta(seconds=seg_idx[-1][1] * 60))
+    return ts_long, op_event, true_bounds
+
+
+def test_adjust_segments_with_changepoints():
+    ts_long, op_event, true_bounds = make_synthetic_batch()
+    segs = build_segments_from_events(op_event)
+    segs_adj = adjust_segments_with_changepoints(ts_long, segs)
+    segs_adj = segs_adj.sort_values("start_ts").reset_index(drop=True)
+    for i in range(len(segs_adj)):
+        assert abs((segs_adj.loc[i, "start_ts"] - true_bounds[i]).total_seconds()) <= 180
+        assert abs((segs_adj.loc[i, "end_ts"] - true_bounds[i + 1]).total_seconds()) <= 180
+
+
+def test_build_stage_features_flags():
+    ts_long, op_event, _ = make_synthetic_batch()
+    segs = build_segments_from_events(op_event)
+    segs_adj = adjust_segments_with_changepoints(ts_long, segs)
+    feat = build_stage_features(ts_long, segs_adj)
+    # pH window and heat ok should hold for majority of steps
+    assert feat["pH_window"].all()
+    assert feat["heat_ok"].any()
+    # vacuum check specifically for step 7
+    step7 = feat[feat["step"] == 7].iloc[0]
+    assert step7["vacuum_leq_16L"]
+


### PR DESCRIPTION
## Summary
- Detect changepoints for T, pH, Vac and Flow using PELT and refine step segments when multiple signals agree
- Track process state flags `heat_ok`, `pH_window`, and `vacuum_leq_16L` in stage features
- Add unit tests exercising segmentation refinement and new flags on synthetic batches

## Testing
- `pip install -r requirements.txt` *(failed: Could not find a version that satisfies the requirement ruptures>=1.1)*
- `pytest tests/test_stage_segmentation.py -q` *(failed: ModuleNotFoundError: No module named 'ruptures')*


------
https://chatgpt.com/codex/tasks/task_e_689c90a00488832c9d3cc93882d2fe9b