### PR TITLE
Load models at startup and expose process advice APIs

### DIFF
--- a/service/app.py
+++ b/service/app.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from pydantic import BaseModel
-from typing import List, Dict, Optional
-import joblib, os, json
+from typing import Dict
+import joblib
 import numpy as np
 import pandas as pd
 from pathlib import Path
@@ -9,29 +9,39 @@ from tslearn.metrics import soft_dtw
 
 app = FastAPI(title='Industrial AI Process Optimization')
 
+# ---------------------------------------------------------------------------
+# Artifact loading
+# ---------------------------------------------------------------------------
+
 ART = Path(__file__).resolve().parents[0] / 'artifacts'
 ART.mkdir(exist_ok=True)
 
-# lazy load
 _cls = None
 _reg = None
 _proto = None
 _env_lo = None
 _env_hi = None
+
+# per-batch in-memory state
 _state: Dict[str, Dict] = {}
 
-try:
-    _cls = joblib.load(ART / 'cls_pass.pkl')
-    _reg = joblib.load(ART / 'reg_viscosity.pkl')
-except Exception as e:
-    print('Model load warning:', e)
 
-try:
-    _proto = np.load(ART / 'proto_step2_T.npy')
-    _env_lo = np.load(ART / 'envlo_step2_T.npy')
-    _env_hi = np.load(ART / 'envhi_step2_T.npy')
-except Exception as e:
-    print('Golden curve load warning:', e)
+@app.on_event('startup')
+def _load_artifacts() -> None:
+    """Load ML models and golden-curve artifacts when service starts."""
+    global _cls, _reg, _proto, _env_lo, _env_hi
+    try:
+        _cls = joblib.load(ART / 'cls_pass.pkl')
+        _reg = joblib.load(ART / 'reg_viscosity.pkl')
+    except Exception as e:  # pragma: no cover - informational
+        print('Model load warning:', e)
+
+    try:
+        _proto = np.load(ART / 'proto_step2_T.npy')
+        _env_lo = np.load(ART / 'envlo_step2_T.npy')
+        _env_hi = np.load(ART / 'envhi_step2_T.npy')
+    except Exception as e:  # pragma: no cover - informational
+        print('Golden curve load warning:', e)
 
 class Tick(BaseModel):
     ts: str
@@ -54,49 +64,85 @@ def tick(batch_id: str, payload: Tick):
     st['history'].append(payload.signals)
 
     df = pd.DataFrame(st['history'])
-    feats = df.mean().to_frame().T
+    window = min(len(df), 5)
+    feats = df.rolling(window=window).mean().iloc[-1].to_frame().T
+
     deviation = None
-    if _proto is not None:
-        curve = df.get('T', pd.Series(dtype=float)).dropna().values.astype(float)
-        if len(curve) > 1:
-            deviation = float(soft_dtw(curve, _proto))
-    st['deviation'] = deviation
+    envelope_violations = None
+    curve = df.get('T', pd.Series(dtype=float)).dropna().values.astype(float)
+    if _proto is not None and len(curve) > 1:
+        deviation = float(soft_dtw(curve, _proto))
+    if _env_lo is not None and _env_hi is not None and len(curve) > 0:
+        L = min(len(curve), len(_env_lo))
+        env_lo = np.interp(np.linspace(0, 1, L), np.linspace(0, 1, len(_env_lo)), _env_lo)
+        env_hi = np.interp(np.linspace(0, 1, L), np.linspace(0, 1, len(_env_hi)), _env_hi)
+        segment = curve[:L]
+        viol = (segment < env_lo) | (segment > env_hi)
+        envelope_violations = int(viol.sum())
 
     prob = None
     if _cls is not None:
         try:
             prob = float(_cls.predict_proba(feats)[:, 1][0])
         except Exception:
-            prob = None
-    st['pass_prob'] = prob
+            pass
 
     visc = None
     if _reg is not None:
         try:
             visc = float(_reg.predict(feats)[0])
         except Exception:
-            visc = None
-    st['viscosity'] = visc
-    st['features'] = feats.iloc[0].to_dict()
+            pass
 
-    return {'batch_id': batch_id, 'deviation': deviation,
-            'pass_prob': prob, 'viscosity': visc}
+    advice = []
+    if prob is not None and prob < 0.7:
+        advice.append('Low pass probability; review process parameters')
+    if deviation is not None and _env_hi is not None and _env_lo is not None:
+        thresh = float(np.mean(_env_hi - _env_lo))
+        if deviation > thresh:
+            advice.append('Temperature profile deviates from prototype')
+    if envelope_violations is not None and envelope_violations > 0:
+        advice.append('Temperature outside control envelope')
+    if not advice:
+        advice.append('Process on track')
+
+    st.update({
+        'features': feats.iloc[0].to_dict(),
+        'deviation': deviation,
+        'envelope_violations': envelope_violations,
+        'pass_prob': prob,
+        'viscosity': visc,
+        'advice': advice,
+    })
+
+    return {
+        'batch_id': batch_id,
+        'pass_prob': prob,
+        'viscosity': visc,
+        'deviation': deviation,
+        'envelope_violations': envelope_violations,
+        'advice': advice,
+    }
+
+@app.get('/state/{batch_id}')
+def get_state(batch_id: str):
+    st = _state.get(batch_id)
+    if not st:
+        return {'batch_id': batch_id, 'error': 'unknown batch'}
+    data = {k: v for k, v in st.items() if k != 'history'}
+    return {'batch_id': batch_id, **data}
+
 
 @app.get('/advice/{batch_id}')
 def advice(batch_id: str):
     st = _state.get(batch_id)
-    if not st or st.get('pass_prob') is None:
+    if not st:
         return {'batch_id': batch_id, 'advice': ['Insufficient data']}
-
-    adv = []
-    prob = st.get('pass_prob')
-    dev = st.get('deviation')
-    if prob is not None and prob < 0.7:
-        adv.append('Low pass probability; review process parameters')
-    if dev is not None and _env_hi is not None and _env_lo is not None:
-        if dev > float(np.mean(_env_hi - _env_lo)):
-            adv.append('Temperature profile deviates from prototype')
-    if not adv:
-        adv.append('Process on track')
-    return {'batch_id': batch_id, 'pass_prob': prob,
-            'viscosity': st.get('viscosity'), 'advice': adv}
+    return {
+        'batch_id': batch_id,
+        'pass_prob': st.get('pass_prob'),
+        'viscosity': st.get('viscosity'),
+        'deviation': st.get('deviation'),
+        'envelope_violations': st.get('envelope_violations'),
+        'advice': st.get('advice', ['Process on track']),
+    }


### PR DESCRIPTION
## Summary
- Load LightGBM models and golden-curve artifacts on FastAPI startup
- Compute rolling features, Soft-DTW deviation, and envelope violations per batch
- Add `/state` and enhanced `/advice` endpoints delivering KPIs and suggestions

## Testing
- `python -m py_compile service/app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c90a2750c832c98ee1a37e31ca85a