### PR TITLE
Add dashboard UI and KPI endpoints

### DIFF
--- a/dashboard/batch_review.html
+++ b/dashboard/batch_review.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Batch Review</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>Batch Review</h1>
+    <div class="card green">Stage 1: OK</div>
+    <div class="card yellow">Stage 2: Verify pH</div>
+    <div class="card red"><a href="/advice/demo-batch">Stage 3 Issue - view advice</a></div>
+</body>
+</html>

--- a/dashboard/management.html
+++ b/dashboard/management.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Management Dashboard</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>Management</h1>
+    <div class="card green">Yield: 96%</div>
+    <div class="card yellow">Throughput: 85%</div>
+    <div class="card red"><a href="/advice/demo-batch">Viscosity Alert - view advice</a></div>
+</body>
+</html>

--- a/dashboard/optimization_sop.html
+++ b/dashboard/optimization_sop.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Optimization & SOP</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>Optimization & SOP</h1>
+    <div class="card green">Setpoint Range: Temp 95-100°C</div>
+    <div class="card yellow">Setpoint Range: pH 8.5-9.5</div>
+    <div class="card red"><a href="/advice/demo-batch">Review SOP Adjustment</a></div>
+</body>
+</html>

--- a/dashboard/production.html
+++ b/dashboard/production.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Production Monitoring</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>Production Monitoring</h1>
+    <div class="card green">Reactor Temp: 98°C</div>
+    <div class="card yellow">Flow Rate: 9 L/min</div>
+    <div class="card red"><a href="/advice/demo-batch">Pressure High - view advice</a></div>
+</body>
+</html>

--- a/dashboard/style.css
+++ b/dashboard/style.css
@@ -1,0 +1,4 @@
+.card {padding:1em;border:1px solid #ccc;margin:0.5em 0;}
+.green {background-color:#d4edda;}
+.yellow {background-color:#fff3cd;}
+.red {background-color:#f8d7da;}


### PR DESCRIPTION
## Summary
- Add dashboard templates for management, production monitoring, batch review, and optimization/SOP with color-coded KPI cards
- Expose new REST endpoints for KPIs, trends, stage KPIs, and setpoint ranges
- Log advice requests for audit purposes

## Testing
- `python -m py_compile service/app.py`


------
https://chatgpt.com/codex/tasks/task_e_689c90a4064c832cb06441af9e1561c0